### PR TITLE
MorphoDepot tutorial: reconcile with the extension; drop "short-term"

### DIFF
--- a/MorphoDepot/10-collections.md
+++ b/MorphoDepot/10-collections.md
@@ -22,16 +22,18 @@ Everything below happens in the **Collections** tab of the MorphoDepot module (t
 
 ### 10.2 Create a collection (organization members)
 
-1. In the **Create a Collection** section, enter a **Title** — the display name, e.g. `Snakes of Texas`. A short repository name is derived from it automatically. Optionally add a one-line **Description**.
+1. In the **Create a Collection** section, enter a **Title** — the display name, e.g. `Snakes of Texas`. Optionally add a one-line **Description**.
 2. Add member repositories — **at least two**:
-   * Pick a repository from the dropdown (it lists the known MorphoDepot corpus, with species names), **or** paste a GitHub URL, then click **Add**.
+   * Pick a repository from the dropdown (it lists the known MorphoDepot corpus, with species names), **or** paste a GitHub URL, then click **Add**. A pasted repository is checked: it has to be a real MorphoDepot dataset repository, and another collection cannot be a member.
    * Repeat to add more. Use **Remove selected** to drop any you added by mistake.
-3. Click **Create Collection**.
+3. Click **Create Collection**. If a collection with a similar title already exists you are shown it and asked whether to go ahead anyway — adding your datasets to the existing collection is usually the better answer.
 
-What happens: MorphoDepot uses your own `gh` to create a new repository **in the MorphoDepot organization**, seeds it with a canonical `README.md` and a `CURATOR` file (naming you as curator), and tags it `md-collection`. RepoClerk then picks it up and renders it as a gallery of its member datasets.
+What happens: MorphoDepot uses your own `gh` to create a new **public** repository **in the MorphoDepot organization**, seeds it with a canonical `README.md` and a `CURATOR` file (naming you as curator), and tags it `md-collection`. RepoClerk then picks it up and renders it as a gallery of its member datasets.
+
+The repository itself gets a deliberately meaningless name (`collection-` plus a few random characters). The **title** you typed is stored as the repository's **description**, which only a repository admin can change — so the title cannot be altered by a pull request, while the member list in the README stays open to contributions.
 
 > [!TIP]
-> A collection's `README.md` is curated free-form. After creating it, you can edit it on GitHub to add context, section headings, or a narrative. Because membership is just a set of pointers, adding or removing datasets later is simply an edit to the collection repository — the member datasets are never modified.
+> A collection's `README.md` is curated free-form. After creating it, you can edit it on GitHub to add context, section headings, or a narrative — RepoClerk harvests the member links out of whatever you write. Because membership is just a set of pointers, adding or removing datasets later is simply an edit to the collection repository — the member datasets are never modified. To rename a collection, edit the repository **description** in its GitHub settings.
 
 ---
 

--- a/MorphoDepot/2-slicer-setup.md
+++ b/MorphoDepot/2-slicer-setup.md
@@ -6,43 +6,76 @@ _MorphoDepot Tutorial · Part 2 of 10 — Slicer Installation & Setup_
 
 ## **2. Slicer Installation & Setup**
 
-Now that your github credentials are set, you can set up the software.
+Now that your GitHub credentials are set, you can set up the software.
 
 > [!NOTE]
 > [You can skip to Section 2.3](./2-slicer-setup.md#23-verify-connection-the-configure-tab) if you are using MorphoCloud.
 
 ### **2.1 Install Slicer**
 
-1. Go to [download.slicer.org](https://download.slicer.org/).  
+1. Go to [download.slicer.org](https://download.slicer.org/).
 2. Download and install the latest **Stable Release** for your operating system.
 
 ### **2.2 Install Extensions**
 
-1. Open 3D Slicer.  
-2. Navigate to the **Extensions Manager**.  
-3. Search for and install the following extensions:  
-   * SlicerMorph  
-   * MorphoDepot   
-4. **Restart Slicer** to for changes to take effect. 
+1. Open 3D Slicer.
+2. Navigate to the **Extensions Manager**.
+3. Search for and install the following extensions:
+   * SlicerMorph
+   * MorphoDepot
+4. **Restart Slicer** for the changes to take effect.
 
 ### **2.3 Verify Connection (The "Configure" Tab)**
 
-1. Open the **MorphoDepot** module.  
-2. Click the **Configure** tab.  
-3. Enter your information:  
-   * **User Name**: Your full name (e.g., "Jane Smith")  
+1. Open the **MorphoDepot** module.
+2. Click the **Configure** tab.
+3. Enter your information:
+   * **User Name**: Your full name (e.g., "Jane Smith")
    * **User Email**: The email address associated with your GitHub account
 
-These fields are required for accurate commit histories and tracking of the issues. 
+   These fields are required for accurate commit histories and tracking of the issues. If you logged in with `gh auth login -s user:email` (Section 1.3), MorphoDepot fills them in for you from your GitHub profile.
 
-4. Because you completed Section 1, MorphoDepot should be able to detect where git and gh are installed.  
-   * *Troubleshooting:* If you encounter errors, you may need to manually point Slicer to the full path where you installed git or gh (the same path used in Section 1.3).
+4. Because you completed Section 1, MorphoDepot should be able to detect where git and gh are installed.
+   * *Troubleshooting:* If you encounter errors, you may need to manually point Slicer to the full path where you installed git or gh (the same path used in Section 1.3). A portable install that is not on your system PATH works fine — MorphoDepot passes the paths you set here to both tools.
 
-5. **Applying Changes:** After modifying any settings in the Configure tab (repository directory, git path, gh path, or user credentials), click the **Apply Changes** button to reload the module with your new settings. This eliminates the need to restart Slicer after configuration changes. You will not be able to proceed to other tab of MorphoDepot, unless you configure the extension fully. 
+5. **Applying Changes:** After modifying any settings in the Configure tab (repository directory, git path, gh path, or user credentials), click the **Apply Changes** button to reload the module with your new settings. This eliminates the need to restart Slicer after configuration changes. You will not be able to proceed to other tabs of MorphoDepot unless you configure the extension fully.
 
 <img src="./configure-tab.png" width="560">
 
 *The Configure tab. MorphoDepot auto-detects your `git` and `gh` paths after Section 1; enter your name and the email tied to your GitHub account, then click **Apply Changes**. The remaining tabs stay disabled until configuration is complete.*
+
+> [!NOTE]
+> **Shared and lab computers.** MorphoDepot signs in to GitHub *per repository*, through `gh`, for the repositories it clones. It uses whichever account `gh auth status` reports as active and leaves the rest of your machine's git configuration alone — so a credential another person left behind in the system keychain cannot make your commits go up under their name. If you use several GitHub accounts, `gh auth switch` is what selects the one MorphoDepot works as.
+
+### **2.4 Keeping MorphoDepot up to date**
+
+MorphoDepot can update **itself**, in place — you do not have to wait for an Extension Manager build.
+
+This matters because Slicer's extension server only builds MorphoDepot for the Slicer version that is current. If you stay on an older Slicer, the Extension Manager silently stops offering you new versions; the built-in updater does not.
+
+**How it works**
+
+1. The first time you open the MorphoDepot module in a Slicer session, it quietly checks GitHub for a newer version. If there is nothing new, it says nothing at all.
+2. If there is, a banner appears above the tabs — visible from every tab — reading, for example, *"MorphoDepot 2026-08-16 (8707870) is available. You have 2026-07-27 (000f781)."* with three buttons:
+   * **Update Now** — download and install it.
+   * **What's New** — open the list of changes on GitHub.
+   * **Dismiss** — hide the notice until the *next* version is released.
+3. **Update Now** replaces the installed module files, keeping a backup of the previous version so the update can be undone, then verifies what it wrote.
+4. When it finishes, you are asked how to apply it:
+   * **Reload MorphoDepot** — quickest, and it **keeps your scene** (which matters if you have an unsaved segmentation open).
+   * **Restart Slicer** — use this if anything looks wrong after a reload.
+   * **Later** — keep working; the new version takes effect the next time Slicer starts.
+
+**The Configure tab's "MorphoDepot Version" section** shows the same information at any time:
+
+* **Installed** — the date and revision you are running.
+* **Source** — how it was installed: *Extension Manager*, *Developer checkout*, *Built from source*, or *Unrecognized installation*.
+* **Status** — *Up to date*, *Update available: …*, or the reason MorphoDepot will not update this particular installation.
+* **Check for Updates Now** — re-run the check on demand.
+* **Check for updates at startup** — turn the automatic check off if you would rather not have it.
+
+> [!NOTE]
+> MorphoDepot only writes to installations where that is safe: an **Extension Manager** install, or a **clean git clone** of the official repository on the release branch. A build tree, a modified or forked developer checkout, or an unpacked zip is reported but never touched — update those yourself. If it cannot write to its own install directory it says so instead of failing silently.
 
 ---
 

--- a/MorphoDepot/3-prepare-volume.md
+++ b/MorphoDepot/3-prepare-volume.md
@@ -7,34 +7,65 @@ _MorphoDepot Tutorial · Part 3 of 10 — Preparing Data: 3D Volume_
 ## **3. Preparing Data for MorphoDepot Repository: 3D Volume**
 
 > [!CAUTION]
-> **CRITICAL STEP:** Data must be cleaned, posed, and padded *before* uploading. Once a repository is created, the source volume cannot be changed without restarting the project.
+> **CRITICAL STEP: get the volume right before you stage the repository.**
+> Creating a repository *stages* it: MorphoDepot uploads your scan and creates a **private**
+> repository from it. While it is staged you can still correct almost everything — metadata,
+> license, color table, baseline segmentation, screenshots — but the **scan itself is frozen**,
+> and so are the **voxel dimensions and spacing** read from it. The only way to change the scan
+> is to **discard the staged repository and start over**, which means uploading everything again.
 
 ### **3.1 Volume Quality Control**
 
-* **Cleaning:** Ensure the scan has minimal noise and no background artifacts (holders, markers, packing peanuts).  
+* **Cleaning:** Ensure the scan has minimal noise and no background artifacts (holders, markers, packing peanuts).
 * **Orientation:** We suggest aligning the specimen with the standard world axes (Anterior-Posterior, Dorsal-Ventral; see below).
+* **Type:** MorphoDepot takes a **scalar volume** (a normal grayscale image). Label maps, vector volumes, and sequences are not offered in the source-volume selector.
 
 ### **3.2 Cropping and Posing your Data**
 
 Use the **Crop Volume** module in Slicer to prepare the specific Region of Interest (ROI).
 
-1. Load your volume into Slicer.  
-2. Open **Crop Volume**.  
-3. **Reorient:** Use the "Reorient Volume" dropdown to align the specimen using the rotation handles in the 3D viewer. Hit **Apply** when done.   
+1. Load your volume into Slicer.
+2. Open **Crop Volume**.
+3. **Reorient:** Use the "Reorient Volume" dropdown to align the specimen using the rotation handles in the 3D viewer. Hit **Apply** when done.
 4. **Input ROI:** Create a new ROI.
-5. **Crucial:** Set "Fit to Volume" mode to **Align to world axes \+ Resize**. Then, hit **Fit to Volume** button to expand the ROI to span the new alignment.   
-6. Drag the ROI box to encase the specimen with a padding of approximately **5%** of image on all sides.  
-7. **ROI Settings:**  
-   * Set **Interpolated cropping** to "Enabled".  
-   * Set **Fill value** to the background intensity (usually 0 for microCT, and \-1000 for medical CT. If unsure, check specifics for your dataset using the Volumes module).  
-   * Click **Apply**. This creates a new resampled volume in the user specified orientation.  
-8. **Image Metadata:** Check the volume has correct image spacing (resolution) entered.   
-9. **Size:** The final .nrrd file **must be under 2 GB** when saved on disk (with compression enabled). 
+5. **Crucial:** Set "Fit to Volume" mode to **Align to world axes + Resize**. Then, hit **Fit to Volume** button to expand the ROI to span the new alignment.
+6. Drag the ROI box to encase the specimen with a padding of approximately **5%** of image on all sides.
+7. **ROI Settings:**
+   * Set **Interpolated cropping** to "Enabled".
+   * Set **Fill value** to the background intensity (usually 0 for microCT, and -1000 for medical CT. If unsure, check specifics for your dataset using the Volumes module).
+   * Click **Apply**. This creates a new resampled volume in the user specified orientation.
+8. **Image Metadata:** Check the volume has the correct image spacing (resolution) entered, **in millimeters** — convert microns first (10 µm = 0.010 mm). MorphoDepot reads the spacing and the voxel dimensions off the volume at staging, shows them in the confirmation dialog, and stores them in the repository's metadata. They are **not** re-read afterwards, so a wrong spacing cannot be corrected by editing the staged repository — check it now.
+9. **Size:** MorphoDepot saves the volume as a **compressed .nrrd** and checks its size when you stage:
+
+   | Repository type | Where the scan is stored | Size limit |
+   | --- | --- | --- |
+   | **Personal** (your own account) | GitHub release attachment | **2 GB** |
+   | **Archival** (MorphoDepot organization) | Jetstream2 cloud storage | **10 GB** |
+
+   If the volume is over the limit, staging stops with a message telling you which limit you hit. Crop or resample and try again. (See [Part 5](./5-create-repo.md#repository-type-personal-vs-archival) for the difference between the two repository types.)
 
 ### **3.3 File Naming**
 
-* Rename the resulting cropped volume node in the **Data** module.  
-* **Rules:** No spaces. Use alphanumerics, underscores, or dashes only (e.g., Sebastes\_caurinus\_Skull\_01). In general, keep the filename simple. Repository metadata provides far more information about the specimen and the scan that you can possibly include in the filename.
+* Rename the resulting cropped volume node in the **Data** module.
+* **Rules:** No spaces. Use letters, digits, periods, underscores, or dashes, and start and end with a letter or a digit (e.g., `Sebastes_caurinus_Skull_01`). MorphoDepot refuses to stage a volume whose node name breaks this rule, because the name becomes a file name in the repository.
+* In general, keep the name simple. Repository metadata provides far more information about the specimen and the scan than you can possibly fit into a filename.
+
+> [!TIP]
+> The same naming rule applies to the **color table** node ([Part 4](./4-color-table.md)). MorphoDepot checks both names before it uploads anything, so a bad name costs you nothing but a rename — but it is one less thing to fix at the Create tab if you do it now.
+
+### **3.4 What staging freezes, and what stays editable**
+
+You will meet this in detail in [Part 5](./5-create-repo.md#52-what-staging-freezes-and-what-you-can-still-change); it is summarized here because it is what makes this preparation step irreversible.
+
+| Frozen at staging | Editable for as long as the repository is staged |
+| --- | --- |
+| The **source volume** (the scan itself) | The whole accession form (species, sex, stage, modality, contrast, contents, anatomical areas, specimen record URL) |
+| The **voxel dimensions and spacing** read from it | The **license** |
+| The **repository name** | The **color table** (replace it with a different one) |
+| The **repository type** (Personal or Archival) | The **baseline segmentation** (replace it with a different one) |
+| The **owner** — your account or the organization | **Screenshots** (add, delete, re-caption) |
+
+To change anything in the left column you have to discard the staged repository and stage a new one.
 
 ---
 

--- a/MorphoDepot/4-color-table.md
+++ b/MorphoDepot/4-color-table.md
@@ -6,15 +6,23 @@ _MorphoDepot Tutorial · Part 4 of 10 — Preparing Data: Color Table_
 
 ## **4. Preparing Data for MorphoDepot Repository: Color Table with Terminologies.**
 
-You must define what anatomical structures will be segmented. This ensures all collaborators use the exact same terminology for labels. We suggest creating these color table comprehensively (include as much structural detail as possible), You can see some examples of existing terminology color tables at https://github.com/SlicerMorph/terms-and-colors
+You must define what anatomical structures will be segmented. This ensures all collaborators use the exact same terminology for labels. We suggest creating these color tables comprehensively (include as much structural detail as possible). You can see some examples of existing terminology color tables at https://github.com/SlicerMorph/terms-and-colors
 
 ### **4.1 Color Table Creation**
 
-* **Custom Color Table:** Use the `Colors` module of Slicer to create the color table in the csv format. We recommend using **Uberon** anatomical terms as reference. *For more detail about importing and using Uberon See:* [SlicerMorph Color Table Creation Tutorial](https://github.com/SlicerMorph/Tutorials/blob/main/Segmentation/colors-and-terms/README.md)  
+* **Custom Color Table:** Use the `Colors` module of Slicer to create the color table in the csv format. We recommend using **Uberon** anatomical terms as reference. *For more detail about importing and using Uberon See:* [SlicerMorph Color Table Creation Tutorial](https://github.com/SlicerMorph/Tutorials/blob/main/Segmentation/colors-and-terms/README.md)
 
-* **Load from URL:** If you find a directly relevant color table in the referenced Terms-and-Colors repository, you can load it directly into Slicer using the Sample Data modules `Load From URL` feature  
-  * *Example:* Copy the Raw URL of a CSV file (e.g., from the SlicerMorph repo).  
-  * Use the **Sample Data** module \-\> **Load data from URL**.
+* **Load from URL:** If you find a directly relevant color table in the referenced Terms-and-Colors repository, you can load it directly into Slicer using the Sample Data module's `Load From URL` feature
+  * *Example:* Copy the Raw URL of a CSV file (e.g., from the SlicerMorph repo).
+  * Use the **Sample Data** module -> **Load data from URL**.
+
+### **4.2 What MorphoDepot requires of the color table**
+
+* **Name it like a file.** MorphoDepot saves the color table node into the repository under its node name, so the name may contain only letters, digits, periods, underscores, and dashes, and must start and end with a letter or a digit. Rename it in the **Data** module (use the *All nodes* tab, then right-click -> Rename).
+* **Terminology.**
+  * For an **Archival** repository (in the MorphoDepot organization), a real terminology table is **mandatory**: a generic or built-in Slicer table — `Labels`, `GenericAnatomyColors`, `GenericColors`, a continuous colormap such as `Viridis` — is rejected outright, and so is a custom table with any entry missing its terminology. Fix the table, reload it, and try again.
+  * For a **Personal** repository, MorphoDepot offers to fill any missing entries with a default terminology (Tissue, SNOMED CT `85756007`) so a classroom exercise is not blocked by ontology work. You can decline and complete the terminology by hand instead.
+* **Cover what you expect to be segmented.** The color table is what contributors name their segments from, so a missing term is a missing structure. It is easier to add terms now than to reconcile ad-hoc segment names at release time (a color table *can* be replaced later — see [Part 5](./5-create-repo.md#52-what-staging-freezes-and-what-you-can-still-change) and [Part 9](./9-releases.md) — but the segments already named from the old one will not rename themselves).
 
 ---
 

--- a/MorphoDepot/5-create-repo.md
+++ b/MorphoDepot/5-create-repo.md
@@ -72,7 +72,7 @@ Each **Save Changes** rewrites the staged repository as a single clean commit, s
 1. **Repository type** — select **Personal**.
 2. **Subject Data** — choose your **Source volume** and a **Color table**; a **Baseline segmentation** is optional. See the [accession-form reference](#56-reference-the-accession-form).
 3. **Screenshots** *(optional, recommended)* — capture a few views. See the [screenshot reference](#57-reference-screenshots).
-4. **Auto-assign** *(optional, on by default)* — leave "Set the GitHub workflow to auto-assign new issues to their creators" ticked so that students' issues are assigned to them automatically. See [Part 6](./6-project-management.md#63-assigning-issues-owner-action).
+4. **Auto-assign** *(optional, on by default)* — leave "Set the GitHub workflow to auto-assign new issues to their creators" ticked so that students' issues are assigned to them automatically. It works the same for either repository type, and needs the `workflow` scope on your GitHub login. See [Part 6](./6-project-management.md#63-assigning-issues-owner-action).
 5. **Accession Form** — fill in the specimen metadata and choose a **license**. MorphoDepot suggests a repository name from what you enter (e.g. `mus-musculus-microct-whole`) and tells you whether that name is free on your account; edit it if you like.
 6. **Stage** — click **Create (stage privately)** and review the confirmation dialog: destination, repository name, volume, color table, specimen details, and the computed physical size, voxel dimensions and spacing. Click **OK**.
 7. MorphoDepot uploads the scan, creates the private repository, and resets the scene and the form. You are told where to find it again — the **Staged repositories — not yet published** list at the top of the Create tab.
@@ -93,13 +93,14 @@ An **archival** repository lives in the **MorphoDepot organization**, is stored 
 2. **Subject Data** — choose your **Source volume** and a **real terminology color table**. A generic or built-in Slicer color table (Labels, GenericAnatomyColors, a continuous colormap, …) is **rejected**, and so is a table with any entry missing its terminology. If you include a baseline segmentation, it must be built on **this** source volume.
 3. **Accession Form** — fill in the specimen metadata, choose a **license**, set a **repository name**, and tick the **redistribution acknowledgement** in Section 6 (archival only). If the species name does not resolve cleanly in GBIF you get an advisory warning — it never blocks staging, but a reviewer may follow up.
 4. **Screenshots** *(required)* — include at least one screenshot that actually shows the data (and the segmentation, if present).
-5. **Stage** — click **Create (stage privately)** and confirm. The dialog names the organization explicitly, so there is no doubt about where the repository is going. It is staged **privately inside the organization** and appears in the **Staged repositories** list.
-6. **Submit for review** — reopen it and click **Publish**:
+5. **Auto-assign** *(optional, on by default)* — exactly as for a personal repository: leave "Set the GitHub workflow to auto-assign new issues to their creators" ticked so contributors' issues are assigned to them automatically. The option is independent of the repository type.
+6. **Stage** — click **Create (stage privately)** and confirm. The dialog names the organization explicitly, so there is no doubt about where the repository is going. It is staged **privately inside the organization** and appears in the **Staged repositories** list.
+7. **Submit for review** — reopen it and click **Publish**:
    * If your dataset ships a **baseline segmentation**, you are asked *"Who made the baseline segmentation?"* so that people other than yourself can be credited. You are added as lead author automatically; click **Done** if there is no one else to add. Cancelling here cancels the publish.
    * MorphoDepot then runs automated quality controls. If a **hard check fails** you get the specific list of things to fix and the repository stays staged: fix them, **Save Changes**, and click **Publish** again.
    * If the checks pass, a review request is emailed to the MorphoDepot reviewers and the entry in the staged list shows **⏳ pending review**.
-7. **Finish the publish** — when a reviewer approves, you get an email and the entry reads **✓ approved — right-click ▸ Publish**. **Right-click it and choose Publish (make public)**. That final flip is yours to make; do it **within 14 days** of approval.
-8. The dataset is now public inside the organization, and a DOI is minted. Further DOIs follow at each [release](./9-releases.md).
+8. **Finish the publish** — when a reviewer approves, you get an email and the entry reads **✓ approved — right-click ▸ Publish**. **Right-click it and choose Publish (make public)**. That final flip is yours to make; do it **within 14 days** of approval.
+9. The dataset is now public inside the organization, and a DOI is minted. Further DOIs follow at each [release](./9-releases.md).
 
 > [!WARNING]
 > Do **not** reopen an approved repository to edit it. MorphoDepot deliberately refuses — editing would change the reviewed content and invalidate both the review and the DOI. If something really must change after approval, edit it and submit for review again.

--- a/MorphoDepot/5-create-repo.md
+++ b/MorphoDepot/5-create-repo.md
@@ -6,62 +6,109 @@ _MorphoDepot Tutorial · Part 5 of 10 — Creating the Repository_
 
 ## **5. Creating the Repository**
 
-The **Create** tab turns your prepared volume and color table into a MorphoDepot repository. Creation always happens in two steps — you first **stage** the repository privately, then **publish** it — but *how* you publish depends on the repository **type** you pick first.
+The **Create** tab turns your prepared volume and color table into a MorphoDepot repository. It always happens in **two steps**:
 
-1. Open the **MorphoDepot** module and select the **Create** tab.
+1. **Stage** — MorphoDepot uploads your scan and creates a **private** repository from it. Nothing is public, nothing is discoverable, and you can come back to it as often as you like.
+2. **Publish** — you make it public. *How* that works depends on the repository **type** you pick first.
 
-### Repository type: Personal (short-term) vs. Archival
+Open the **MorphoDepot** module and select the **Create** tab.
 
-Your first choice is the repository **type**, and it is **permanent** — it cannot be changed after the repository is staged (switching would mean moving between your personal account and the organization).
+### Repository type: Personal vs. Archival
 
-|  | Personal (short-term) | Archival |
+Your first choice, at the top of the form, is where the repository lives. It is **permanent**: the two types live in different places, so switching later means discarding and starting over.
+
+|  | **Personal** | **Archival** |
 | --- | --- | --- |
 | Who can create | Anyone | MorphoDepot **organization members** only |
-| Where it lives | Your personal GitHub account | The **MorphoDepot organization** |
-| Scan storage | GitHub attachment, up to 2 GB | Jetstream2 cloud storage (10 GB by default) |
+| Where it lives | Your own GitHub account | The **MorphoDepot organization** |
+| Scan storage | GitHub attachment, up to **2 GB** | Jetstream2 cloud storage, up to **10 GB** |
 | Citable with a DOI | No | **Yes** — minted through Zenodo at each release |
-| Review to publish | None — publishes directly | Editorial review before it goes public |
-| Governance | Yours alone; delete anytime | Community-governed |
-| Best for | Teaching, drafts, experiments | Lasting, citable datasets |
+| Publishing | Directly, no review | Editorial review before it goes public |
+| Governance | Yours alone; delete anytime | Community-governed; publishing is a one-way door |
+| Releases | Not applicable | Versioned, citable [releases](./9-releases.md) |
+
+**When to choose Personal.** Any time you want the repository to stay entirely under your own control. A course exercise or a workshop dataset that you will delete at the end of term is the most common case, but it is not the only one — you may simply not be an organization member yet, you may be trying the workflow out, the data may not be yours to deposit permanently, or you may want to keep the ability to rename, unpublish, or delete the repository at will. Personal repositories are ordinary MorphoDepot repositories: they are searchable, other people can be assigned issues on them, and the whole segment/review/merge cycle works exactly the same.
+
+**When to choose Archival.** When the dataset is meant to last and to be cited — a published study, a reference dataset, anything you want other people to build on over years. Archival datasets are the ones that get DOIs and shared stewardship, and that is also what they cost: once public, you cannot quietly delete or hide one.
 
 > [!NOTE]
-> The **Archival** option is available only to MorphoDepot **organization members**. If you are not a member it is disabled, and you are guided to create a **Personal** repository instead (or to join the organization from the [MorphoDepot landing page](https://morphodepot.org)).
+> The **Archival** option is disabled if MorphoDepot can confirm you are not an organization member; hovering it explains why. You can create a **Personal** repository right away, or join the organization from the [MorphoDepot landing page](https://morphodepot.org).
 
-The two sections below are **standalone walkthroughs** — follow the one that matches your choice. Both share the same accession form and screenshot tools; those field-by-field details are collected once in the [reference](#53-reference-the-accession-form) at the end so they are not repeated.
+### **5.1 Before you start**
 
-### **5.1 Creating a Personal (Short-term) Repository**
+Have all of this ready in the scene *before* you open the Create tab:
 
-A **personal** repository lives on your own GitHub account. It needs no organization membership, you manage (or delete) it entirely on your own, it publishes directly with **no review**, and it is **not citable** (no DOI). Terminology rules are relaxed. Use it for teaching, workshops, drafts, and experiments.
+* A **source volume** — cleaned, posed, cropped, with correct spacing in mm, and named with letters, digits, `.`, `-`, `_` only ([Part 3](./3-prepare-volume.md)).
+* A **color table** — same naming rule; for an archival repository it must be a real terminology table ([Part 4](./4-color-table.md)).
+* *(Optional)* A **baseline segmentation** built on that same volume, if you want contributors to start from existing work.
 
-1. **Repository type** — select **Short-term / Personal**.
-2. **Subject Data** — choose your **Source Volume** and a **Color Table** (a baseline segmentation is optional). See the [accession-form reference](#53-reference-the-accession-form).
-3. **Accession Form** — fill in the specimen metadata, choose a **license**, and set a **repository name**. See the [reference](#53-reference-the-accession-form).
-4. **Screenshots** *(optional)* — capture a few views to showcase the data. See the [screenshot reference](#54-reference-screenshots).
-5. **Stage** — click **Create (stage privately)**, review the confirmation dialog (dimensions, spacing, size, specimen info), and click **Proceed**. The repository is created **privately on your account** and appears in the **Unpublished staged repositories** list, where you can reopen it to edit or **Discard** it.
-6. **Publish** — select it in that list and click **Publish**. It becomes **public on your personal account immediately** — no review, no DOI. *(If you are not an organization member, enter a contact email before Publish is enabled.)*
+### **5.2 What staging freezes, and what you can still change**
+
+This is the part that catches people out, so it is worth stating plainly. When you click **Create (stage privately)**, MorphoDepot saves the volume, uploads it, creates the private repository, pushes the metadata, and then **deletes its local working copy** — the multi-gigabyte scan does not linger on your disk.
+
+**Frozen at staging — changing any of these means discarding and starting over:**
+
+* the **source volume** (the scan);
+* the **voxel dimensions and spacing** read from it — they are copied into the repository's metadata and never re-read;
+* the **repository name** (the field becomes read-only when you reopen the repository);
+* the **repository type** (the selector is hidden while you are editing a staged repository);
+* the **owner** — your account, or the organization.
+
+**Editable for as long as the repository is staged — reopen, change, click Save Changes, repeat:**
+
+* every answer on the **accession form** — species, sex, developmental stage, modality, contrast, image contents, anatomical areas, specimen record URL;
+* the **license** (the `LICENSE.txt` file is rewritten to match);
+* the **color table** — by selecting a *different* color table node;
+* the **baseline segmentation** — by selecting a *different* segmentation node;
+* the **screenshots** — add, delete, or re-caption them.
+
+> [!IMPORTANT]
+> The color table and the baseline segmentation are **replaced**, not edited in place. If you reopen a staged repository and edit the loaded baseline segmentation in the scene, MorphoDepot refuses to save it and asks you to prepare the finished segmentation separately and load it as a new node. Same for the color table: fix it, load it, and select it.
+
+Each **Save Changes** rewrites the staged repository as a single clean commit, so the published history stays tidy — as if you had created it correctly the first time.
+
+### **5.3 Creating a Personal repository**
+
+1. **Repository type** — select **Personal**.
+2. **Subject Data** — choose your **Source volume** and a **Color table**; a **Baseline segmentation** is optional. See the [accession-form reference](#56-reference-the-accession-form).
+3. **Screenshots** *(optional, recommended)* — capture a few views. See the [screenshot reference](#57-reference-screenshots).
+4. **Auto-assign** *(optional, on by default)* — leave "Set the GitHub workflow to auto-assign new issues to their creators" ticked so that students' issues are assigned to them automatically. See [Part 6](./6-project-management.md#63-assigning-issues-owner-action).
+5. **Accession Form** — fill in the specimen metadata and choose a **license**. MorphoDepot suggests a repository name from what you enter (e.g. `mus-musculus-microct-whole`) and tells you whether that name is free on your account; edit it if you like.
+6. **Stage** — click **Create (stage privately)** and review the confirmation dialog: destination, repository name, volume, color table, specimen details, and the computed physical size, voxel dimensions and spacing. Click **OK**.
+7. MorphoDepot uploads the scan, creates the private repository, and resets the scene and the form. You are told where to find it again — the **Staged repositories — not yet published** list at the top of the Create tab.
+8. **Publish** — double-click it in that list to reopen it. The **Make Repository Public** section appears at the bottom of the tab. Enter a **contact email** — MorphoDepot pre-fills it from your GitHub account when it can read it, and you can change it — then click **Publish**. It is used to reach you about MorphoDepot, is submitted only at publish (never for a repository you discard), and is not stored in the repository. Organization members are not asked: their address is already on file from ORCID onboarding.
+9. The repository becomes **public on your account immediately** — no review — its GitHub page opens in your browser, and it becomes discoverable in [Search](./8-search.md) once the index picks it up.
 
 > [!NOTE]
-> **Relaxed terminology for personal repositories:** if your color table lacks complete terminology information, MorphoDepot can automatically assign default terminology entries so the repository can still be created (every entry is assigned to Tissue type with the SNOMED CT code `85756007`). This is intended for quick classroom exercises where formal ontology linking is not required.
+> **Relaxed terminology for personal repositories:** if your color table lacks complete terminology information, MorphoDepot offers to fill in default terminology entries so the repository can still be created (every entry is assigned to Tissue type with the SNOMED CT code `85756007`). This is intended for quick classroom exercises where formal ontology linking is not required. Archival repositories do not get this shortcut.
 
-### **5.2 Creating an Archival Repository**
+### **5.4 Creating an Archival repository**
 
-An **archival** repository lives in the **MorphoDepot organization**, is stored on dedicated cloud storage, and is **community-governed**. It becomes **citable with a DOI** at its first release that contains a segmentation. Use it for research publications and datasets meant for long-term citation.
+An **archival** repository lives in the **MorphoDepot organization**, is stored on dedicated cloud storage, and is **community-governed**. It becomes **citable with a DOI** at its first release that contains a segmentation.
 
 > [!IMPORTANT]
 > Only MorphoDepot **organization members** can create archival datasets — join from the [MorphoDepot landing page](https://morphodepot.org). Publishing one is a **one-way door**: while it is private and staged you can discard it freely, but once it is **public you cannot quietly delete or hide it** — removal becomes an organization-level action. That durable commitment is what makes its DOI meaningful.
 
 1. **Repository type** — select **Archival**. *(Disabled if you are not an organization member.)*
-2. **Subject Data** — choose your **Source Volume** and a **real terminology Color Table** (a plain or default Slicer color table is rejected). If you include a baseline segmentation, it must be built on **this** source volume. See the [accession-form reference](#53-reference-the-accession-form).
-3. **Accession Form** — fill in the specimen metadata, choose a **license**, set a **repository name**, and complete the **redistribution acknowledgement**. See the [reference](#53-reference-the-accession-form).
-4. **Screenshots** *(required)* — include at least one screenshot that actually shows the data (and the segmentation, if present). See the [screenshot reference](#54-reference-screenshots).
-5. **Stage** — click **Create (stage privately)**, review the confirmation dialog, and click **Proceed**. The repository is staged **privately inside the organization** and appears in the **Unpublished staged repositories** list.
-6. **Publish → editorial review** — select it and click **Publish** to submit for review. The staged entry shows **pending review**; once an editor approves it, it reads **✓ approved — click Publish to finish**, and clicking **Publish** again completes the flip to **public inside the organization**. The dataset is now citable — a DOI is minted at each [release](./9-releases.md).
+2. **Subject Data** — choose your **Source volume** and a **real terminology color table**. A generic or built-in Slicer color table (Labels, GenericAnatomyColors, a continuous colormap, …) is **rejected**, and so is a table with any entry missing its terminology. If you include a baseline segmentation, it must be built on **this** source volume.
+3. **Accession Form** — fill in the specimen metadata, choose a **license**, set a **repository name**, and tick the **redistribution acknowledgement** in Section 6 (archival only). If the species name does not resolve cleanly in GBIF you get an advisory warning — it never blocks staging, but a reviewer may follow up.
+4. **Screenshots** *(required)* — include at least one screenshot that actually shows the data (and the segmentation, if present).
+5. **Stage** — click **Create (stage privately)** and confirm. The dialog names the organization explicitly, so there is no doubt about where the repository is going. It is staged **privately inside the organization** and appears in the **Staged repositories** list.
+6. **Submit for review** — reopen it and click **Publish**:
+   * If your dataset ships a **baseline segmentation**, you are asked *"Who made the baseline segmentation?"* so that people other than yourself can be credited. You are added as lead author automatically; click **Done** if there is no one else to add. Cancelling here cancels the publish.
+   * MorphoDepot then runs automated quality controls. If a **hard check fails** you get the specific list of things to fix and the repository stays staged: fix them, **Save Changes**, and click **Publish** again.
+   * If the checks pass, a review request is emailed to the MorphoDepot reviewers and the entry in the staged list shows **⏳ pending review**.
+7. **Finish the publish** — when a reviewer approves, you get an email and the entry reads **✓ approved — right-click ▸ Publish**. **Right-click it and choose Publish (make public)**. That final flip is yours to make; do it **within 14 days** of approval.
+8. The dataset is now public inside the organization, and a DOI is minted. Further DOIs follow at each [release](./9-releases.md).
+
+> [!WARNING]
+> Do **not** reopen an approved repository to edit it. MorphoDepot deliberately refuses — editing would change the reviewed content and invalidate both the review and the DOI. If something really must change after approval, edit it and submit for review again.
 
 **Archival requirements (checked automatically).** Publishing an archival dataset passes a short **editorial review** — in the spirit of a journal's handling editor (the PLOS ONE model): the editor confirms the dataset is **sound and well-formed**, not that the segmentation is anatomically perfect or important. When you publish (or cut a release), the app re-checks your latest commit — a **hard** check that fails is bounced straight back with a list of fixes, while a **soft** finding is flagged for the editor. Design your dataset to meet these from the start:
 
 1. **Name it for the specimen** — `Genus-species` plus what the dataset contains (e.g., `Ariopsis-felis-cranium`), not `my-repo`, `project1`, or `test123`.
 2. **Segment with real terminology** *(hard)* — a real terminology color table with populated ontology codes (Category, Type, Region); every segment named from it; names unique.
-3. **Describe a real specimen** — a real species (checked against GBIF) and, if accessioned, a resolvable iDigBio record.
+3. **Describe a real specimen** — a real species (checked against GBIF) and, if accessioned, a resolvable public collection record.
 4. **Set a correct voxel size in millimeters** — a physically plausible scale; convert microns first (10 µm = 0.010 mm).
 5. **Build any baseline on the source volume** *(hard)* — its reference geometry must match the scan, and its segments follow the terminology rules above.
 6. **Provide a license and a screenshot** *(hard)* — CC BY 4.0 or CC BY-NC 4.0, and at least one screenshot that actually shows the data.
@@ -71,23 +118,38 @@ In return, archival datasets give contributors automatic credit (verified ORCID 
 > [!NOTE]
 > The authoritative, up-to-date requirements are the **[Community Guidelines for MorphoDepot Archival Datasets](https://github.com/MorphoDepot/docs/blob/main/MorphoDepot-archival-guidelines.md)**.
 
-### **5.3 Reference: the accession form**
+### **5.5 Managing staged repositories**
 
-Both repository types use the same accession form. Fill out the metadata — this generates the `README.md` for the repository.
+The **Staged repositories — not yet published** list at the top of the Create tab is your safety net. It is read live from GitHub, not from anything stored on your computer, so it works after a crash, after closing Slicer, and from a different machine.
 
-* **Subject Type:** Biological Specimen vs. Other.
-* **Accession Status:**
-  * *Accessioned:* Provide the institution code and catalog number (links to iDigBio if applicable).
-  * *Non-Accessioned:* Provide a unique identifier.
-* **Taxonomy:** Enter the **Species Name**. Verify spelling against Linnean hierarchies.
-* **Biological Details:** Sex and Developmental Stage (if known).
-* **Imaging Details:** Modality (CT, MRI, etc.) and contrast staining info.
-* **License:**
+* **Double-click** an entry to reopen it: MorphoDepot clones it, downloads the scan, pre-fills the accession form from what was submitted, and reloads the color table, baseline segmentation, and screenshots. The section header changes to *"Editing staged repository: …"*.
+* **Save Changes** applies your edits without publishing. Do it as many times as you need.
+* **Right-click** an entry for *Open the private repo in browser*, *Load the repo to edit*, or — for an approved archival dataset — *Publish (make public)*.
+* **Refresh** re-queries GitHub.
+* **Discard** abandons a staged repository. For a personal repository MorphoDepot opens its GitHub **Settings** page so you can delete it yourself from the Danger Zone (MorphoDepot never asks for permission to delete your repositories); for an organization repository it is marked as discarded, its stored scan is released, and it disappears from the list.
+
+> [!NOTE]
+> **Housekeeping.** A staged repository is not free — its scan is already uploaded. If yours is still unpublished after a week you get a reminder email, and unfinished staged repositories may be removed by a MorphoDepot administrator after four weeks. Publish it or discard it.
+
+> [!TIP]
+> If the exact same scan (byte-for-byte) is already in another MorphoDepot repository, the staged status line says so and you are asked to confirm before publishing. That is usually a sign of an accidental duplicate.
+
+### **5.6 Reference: the accession form**
+
+Both repository types use the same accession form. Fill out the metadata — this generates the `README.md` for the repository and the `MorphoDepotAccession.json` file behind [Search](./8-search.md).
+
+* **Subject Type:** Biological specimen vs. Other. Choosing *Other* replaces the specimen sections with a free-text description.
+* **Acquisition type:** Non-accessioned, or from an accessioned specimen (a natural history collection).
+* **Accessioned specimen:** paste the **record URL** from a public database — GBIF, iDigBio, or Arctos are all understood, and MorphoDepot extracts the Darwin Core identifier (e.g. `UWBM:Mamm:82522`) for the README. A missing or unrecognized URL never blocks staging.
+* **Species information:** enter **Genus species** (two words). Use **Search taxon in GBIF** to look one up and insert the exact spelling, plus **sex** and **developmental stage**.
+* **Image data description:** modality, contrast staining, and whole vs. partial specimen (a partial specimen also asks which anatomical areas are present).
+* **Licensing:**
   * *CC BY 4.0 (preferred):* Open, attribution required.
   * *CC BY-NC 4.0:* Open, attribution required, non-commercial only.
-* **Repository Name:** Create a short, unique name (no spaces, e.g., `Project_FishSkull_2024`).
+  * Archival repositories additionally require the redistribution acknowledgement.
+* **Github:** the **repository name** — suggested from your metadata, editable, and checked for availability as you type. Keep it short, and name it for the specimen.
 
-### **5.4 Reference: screenshots**
+### **5.7 Reference: screenshots**
 
 You can capture and annotate screenshots to showcase your dataset. These images are embedded in the repository's README and shown in search results.
 

--- a/MorphoDepot/6-project-management.md
+++ b/MorphoDepot/6-project-management.md
@@ -4,43 +4,49 @@ _MorphoDepot Tutorial · Part 6 of 10 — Project Management & Assignments_
 
 ---
 
-## **6\. Project Management & Assignments**
+## **6. Project Management & Assignments**
 
-In MorphoDepot, tasks are tracked via GitHub Issues. The workflow is bidirectional: **The Student creates the Issue** (requesting the work), and **The Owner assigns it back** **to the student for them to begin to work on the task.** It may seem more logical for instructors to create issues rather than students creating them, but GitHub will only allow you to assign issues to users who have expressed interest in the issue by creating or commenting on them.
+In MorphoDepot, tasks are tracked via GitHub Issues. The workflow is bidirectional: **the student creates the Issue** (requesting the work), and **the issue is then assigned back to them** so they can begin. It may seem more logical for instructors to create issues rather than students creating them, but GitHub will only allow you to assign issues to users who have expressed interest in the issue by creating or commenting on them.
 
 ### **6.1 Preparation (Owner)**
 
-1. **Define Assignments:** Create a list of who is responsible for which anatomy (e.g., "Student A: Mandible", "Student B: Braincase").  
-2. **Distribute URL:** Send the link to your new GitHub Repository to your students/collaborators.  
+1. **Define Assignments:** Create a list of who is responsible for which anatomy (e.g., "Student A: Mandible", "Student B: Braincase").
+2. **Distribute URL:** Send the link to your new GitHub Repository to your students/collaborators.
 3. **Instruct:** Tell students to navigate to the "Issues" tab of that repository.
 
 ### **6.2 Creating Issues (Student Action)**
 
 *Instruct your students to follow these steps:*
 
-1. Navigate to the repository on GitHub.  
-2. Click the **Issues** tab.  
-3. Click the green **New Issue** button.  
-4. **Title:** Enter a specific title using a standard convention (e.g., LastName\_StructureName).  
-5. **Description:** Briefly describe the task (e.g., "I will be segmenting the pectoral girdle").  
+1. Navigate to the repository on GitHub.
+2. Click the **Issues** tab.
+3. Click the green **New Issue** button.
+4. **Title:** Enter a specific title using a standard convention (e.g., LastName_StructureName).
+5. **Description:** Briefly describe the task (e.g., "I will be segmenting the pectoral girdle").
 6. Click **Submit New Issue**.
 
 ### **6.3 Assigning Issues (Owner Action)**
 
-*Once students have created their issues, you must assign them:*
+**If you left "auto-assign" ticked when you created the repository** ([Part 5](./5-create-repo.md#53-creating-a-personal-repository)), there is nothing to do: GitHub assigns each new issue to whoever opened it, within seconds. This is the recommended setup for a class — it removes the step instructors most often forget.
 
-1. Navigate to the repository **Issues** tab on GitHub.  
-2. Open an issue created by a student.  
-3. Look at the right-hand sidebar for the **Assignees** section.  
-4. Click the gear icon and select the student's username from the list.  
+*Otherwise, assign them by hand once students have created their issues:*
+
+1. Navigate to the repository **Issues** tab on GitHub.
+2. Open an issue created by a student.
+3. Look at the right-hand sidebar for the **Assignees** section.
+4. Click the gear icon and select the student's username from the list.
    * *Note:* This step is critical. If the student is not explicitly listed in the "Assignees" field, MorphoDepot will not download the task to their computer.
+
+> [!NOTE]
+> Auto-assignment is a small GitHub Actions workflow that MorphoDepot puts in the repository at creation. It needs your GitHub login to carry the `workflow` scope; if it does not, the option is offered but disabled, and running `gh auth refresh -s workflow` in a terminal enables it for the *next* repository you create. It cannot be added to a repository after the fact from the extension — assign by hand there.
 
 ### **6.4 Starting Work (Student Action)**
 
-1. Student opens Slicer \-\> **MorphoDepot** \-\> **Annotate** tab.  
-2. Clicks **Refresh GitHub**.  
-3. The issue (now assigned to them) will appear in the list.  
+1. Student opens Slicer -> **MorphoDepot** -> **Annotate** tab.
+2. Clicks **Refresh Github**. (The list is read straight from GitHub, so an issue assigned a moment ago is already there. The button also shows which GitHub account you are working as.)
+3. The issue (now assigned to them) will appear in the list.
 4. Student double-clicks the issue to download the data.
+   * MorphoDepot creates their **fork** of the repository the first time, keeps an existing fork up to date, and starts the new `issue-N` branch from the repository's latest published state — so work always begins from the current baseline, not from a stale copy.
 5. **Automatic Baseline Import:** If the repository owner included a baseline segmentation when creating the repository, it will be automatically imported into the student's working segmentation. This allows students to:
    * Start from a partial segmentation provided by the instructor
    * See reference boundaries for complex structures
@@ -53,22 +59,22 @@ In MorphoDepot, tasks are tracked via GitHub Issues. The workflow is bidirection
 
 As you work in the Segment Editor, MorphoDepot automatically monitors your changes:
 
-* **Modified segments**: Existing segments you've edited  
-* **Added segments**: New segments you've created  
-* **Removed segments**: Segments you've deleted  
+* **Modified segments**: Existing segments you've edited
+* **Added segments**: New segments you've created
+* **Removed segments**: Segments you've deleted
 * **Renamed segments**: Segments whose names have changed
 
 **6.5.2 The Commit Message Interface**
 
 In the Annotate tab, you'll see three text fields:
 
-1. **Commit Title** (auto-generated, editable):  
-   * Shows a summary like: "Edited issue-5 \- 3 modified, 2 added"  
-   * You can edit this to add your own custom title  
-2. **Commit Body** (optional):  
-   * Add any additional notes or explanations  
-   * Example: "Refined the boundary between the frontal and parietal bones"  
-3. **Auto-generated Details** (read-only, grey box):  
+1. **Commit Title** (auto-generated, editable):
+   * Shows a summary like: "Edited issue-5 - 3 modified, 2 added"
+   * You can edit this to add your own custom title
+2. **Commit Body** (optional):
+   * Add any additional notes or explanations
+   * Example: "Refined the boundary between the frontal and parietal bones"
+3. **Auto-generated Details** (read-only, grey box):
    * Lists specific segment names (see the screenshot)
 
 <img src="./annotate-commit.png" width="760">
@@ -77,28 +83,30 @@ In the Annotate tab, you'll see three text fields:
 
 **6.5.3 Committing Your Work**
 
-1. Review the auto-generated message  
-2. (Optional) Edit the title or add a body message  
-3. Click **Commit and Push**  
-   * The first time you commit, a Pull Request is automatically created (as a Draft)  
-   * Subsequent commits update the same Pull Request  
+1. Review the auto-generated message
+2. (Optional) Edit the title or add a body message
+3. Click **Commit and Push**
+   * The first time you commit, a Pull Request is automatically created (as a Draft)
+   * Subsequent commits update the same Pull Request
 4. The message fields clear, ready for your next save
 
 **Best Practice**:
 
-* Commit frequently (every 20-30 minutes)  
-* The auto-generated details provide a perfect audit trail  
-* Add custom notes in the body only when you need to explain *why* you made changes  
+* Commit frequently (every 20-30 minutes)
+* The auto-generated details provide a perfect audit trail
+* Add custom notes in the body only when you need to explain *why* you made changes
 * Optional: navigate to the GitHub issues page and add extra comments or screenshots illustrating the changes you made.
 
+> [!NOTE]
+> If your GitHub sign-in has expired, **Commit and Push** tells you exactly that: your segmentation is saved on your computer and nothing is lost — run `gh auth login` in a terminal, then click Commit again.
 
 ### **6.6 Submitting for Review (Student Action)**
 
 When the student has completed the segmentation:
 
-1. Click **Commit and Push** one last time.  
-2. Click the **Request PR Review** button.  
-3. This signals to GitHub that the work is finished and ready for the instructor to inspect. The issue will now appear in the Owner's "Review" tab.
+1. Click **Commit and Push** one last time.
+2. Click the **Request PR review** button.
+3. This signals to GitHub that the work is finished and ready for the instructor to inspect. The scene is cleared and the issue now appears in the Owner's "Review" tab.
 
 ---
 

--- a/MorphoDepot/6-project-management.md
+++ b/MorphoDepot/6-project-management.md
@@ -38,7 +38,11 @@ In MorphoDepot, tasks are tracked via GitHub Issues. The workflow is bidirection
    * *Note:* This step is critical. If the student is not explicitly listed in the "Assignees" field, MorphoDepot will not download the task to their computer.
 
 > [!NOTE]
-> Auto-assignment is a small GitHub Actions workflow that MorphoDepot puts in the repository at creation. It needs your GitHub login to carry the `workflow` scope; if it does not, the option is offered but disabled, and running `gh auth refresh -s workflow` in a terminal enables it for the *next* repository you create. It cannot be added to a repository after the fact from the extension — assign by hand there.
+> **How it works, and its one prerequisite.** Auto-assignment is a small GitHub Actions workflow that MorphoDepot commits into the repository **at creation**. It runs on GitHub, triggered whenever an issue is opened, and uses GitHub's own per-run token — there is nothing to configure and no secret to manage.
+>
+> Writing a file under `.github/workflows/` requires your GitHub login to carry the **`workflow` scope**. If it does not, the checkbox is shown unticked and disabled with a hint. To grant it, run `gh auth refresh -s workflow` in a terminal and then return to the **Create** tab — MorphoDepot re-checks the scope every time you enter the tab, so it takes effect immediately; no Slicer restart, no module reload.
+>
+> The workflow can only be added when the repository is created. MorphoDepot will not add it to an existing repository — assign issues by hand there, or add the workflow file yourself on GitHub.
 
 ### **6.4 Starting Work (Student Action)**
 

--- a/MorphoDepot/6-project-management.md
+++ b/MorphoDepot/6-project-management.md
@@ -27,7 +27,7 @@ In MorphoDepot, tasks are tracked via GitHub Issues. The workflow is bidirection
 
 ### **6.3 Assigning Issues (Owner Action)**
 
-**If you left "auto-assign" ticked when you created the repository** ([Part 5](./5-create-repo.md#53-creating-a-personal-repository)), there is nothing to do: GitHub assigns each new issue to whoever opened it, within seconds. This is the recommended setup for a class — it removes the step instructors most often forget.
+**If you left "auto-assign" ticked when you created the repository** — an option offered for [either repository type](./5-create-repo.md#5-creating-the-repository) — there is nothing to do: GitHub assigns each new issue to whoever opened it, within seconds. This is the recommended setup for a class — it removes the step instructors most often forget.
 
 *Otherwise, assign them by hand once students have created their issues:*
 

--- a/MorphoDepot/7-review.md
+++ b/MorphoDepot/7-review.md
@@ -4,20 +4,21 @@ _MorphoDepot Tutorial · Part 7 of 10 — Reviewing & Merging Submissions_
 
 ---
 
-## **7\. Reviewing & Merging Submissions**
+## **7. Reviewing & Merging Submissions**
 
 As the Project Owner, you review work directly inside Slicer.
 
 ### **7.1 The Review Workflow**
 
-1. Open MorphoDepot \-\> **Review** tab.  
-2. Click **Refresh GitHub**.  
-   * This pulls all "Open Pull Requests" (submitted assignments) from your repositories.
+1. Open MorphoDepot -> **Review** tab.
+2. Click **Refresh Github**.
+   * This pulls all open Pull Requests (submitted assignments) from the repositories you are the reviewer for: the MorphoDepot repositories you **own**, plus organization repositories whose `CURATOR` file names you.
+   * The list is queried from GitHub each time you click it, so a submission made seconds ago is already there.
 3. **Filtering PRs:** Use the **Hide Drafts** checkbox to control which Pull Requests are displayed:
    * **Checked (default):** Shows only PRs that are "Ready for Review"—these are submissions where students have clicked **Request PR Review**
    * **Unchecked:** Shows all PRs including drafts—useful for monitoring work-in-progress from students who haven't yet submitted for review  
-4. **Select a Request:** Double-click on a row in the table to download the student's segmentation overlay.  
-5. **Inspect:** Use Slicer's 2D and 3D views to check the quality.  
+4. **Select a Request:** Double-click an entry in the list to download the student's segmentation overlay.
+5. **Inspect:** Use Slicer's 2D and 3D views to check the quality.
    * *Comparison:* You can use the **Segment Comparison** module (from SlicerRT) to compare against a ground truth if available.
 
 <img src="./review-tab.png" width="760">
@@ -30,7 +31,8 @@ Once you have inspected the work, you have two choices:
 
 * **Choice A: Approve & Merge:**  
   * If the segmentation is accurate, click the **Approve Pull Request** button.  
-  * This merges the student's segmentation into the main branch of the repository, finalizing that specific anatomy. This also closes the issue the student opened. So at this point no future work is possible (unless the student opens a new issue).   
+  * This merges the student's segmentation into the main branch of the repository, finalizing that specific anatomy. This also closes the issue the student opened. So at this point no future work is possible (unless the student opens a new issue).
+  * The scene is cleared afterwards and MorphoDepot confirms that the pull request was approved and merged.
 * **Choice B: Request Changes:**  
   * If the work needs correction, type your feedback into the text box and click **Request Changes**.  
   * **Result:** This reverts the Pull Request status to "Draft". The work is sent back to the student, and it will no longer appear in your "Ready for Review" queue until they resubmit.
@@ -41,7 +43,7 @@ If you requested changes, the student needs to follow this specific workflow to 
 
 1. **Viewing Feedback:**  
    * Select your active Pull Request from the list  
-   * Click the **"PR Link"** button (becomes enabled when a PR is selected)  
+   * In the **Annotate** tab's *Pull requests* section, select the pull request and click **Open PR page** (it becomes enabled when one is selected)
    * This opens the Pull Request page on GitHub in your web browser  
    * You can now:  
      1. Read detailed review comments  
@@ -52,8 +54,11 @@ If you requested changes, the student needs to follow this specific workflow to 
    * The student returns to Slicer and edits the segmentation based on the feedback.  
    * They click **Commit and Push** to save the changes.  
 3. **Resubmitting:**  
-   * Because the status was reverted to "Draft," the student **must** click the **Request PR Review** button again.  
+   * Because the status was reverted to "Draft," the student **must** click the **Request PR review** button again.
    * Only after this button is clicked will the assignment reappear in your Review tab.
+
+> [!NOTE]
+> **A second, separate kind of review.** MorphoDepot reviewers (the organization's reviewer team) also see a **Repositories awaiting review (reviewers only)** section at the top of this tab. That is the editorial check that lets a new *archival dataset* or a *release* go public ([Part 5](./5-create-repo.md#54-creating-an-archival-repository), [Part 9](./9-releases.md)) — it has nothing to do with reviewing segmentation pull requests, and it is hidden unless you are on that team.
 
 ---
 

--- a/MorphoDepot/8-search.md
+++ b/MorphoDepot/8-search.md
@@ -11,11 +11,12 @@ The Search tab allows you to discover and preview MorphoDepot repositories creat
 **8.1 Initial Setup**
 
 1. Open the MorphoDepot module and select the **Search** tab  
-2. Click **"Load Searchable Repository Data"**  
-   * MorphoDepot downloads metadata from all public MorphoDepot repositories  
-   * This includes accession data, volume size, dimensions, and screenshots  
-   * Data is cached locally to speed up future searches  
-   * **Wait time**: 30 seconds to several minutes depending on the number of repositories (data will be cached to subsequent loads will be faster).  
+2. Click **"Load Searchable Repository Data"**
+   * MorphoDepot downloads metadata for all public MorphoDepot repositories from the central index
+   * This includes accession data, volume size, dimensions, and screenshots
+   * Data is cached locally to speed up future searches
+   * **Wait time**: 30 seconds to several minutes depending on the number of repositories (data will be cached so subsequent loads will be faster).
+   * Only published repositories are listed. Repositories you have staged but not yet published are private and never appear here; [collections](./10-collections.md) are excluded too.
 3. Once loading completes:  
    * The search interface becomes enabled  
    * The results table populates with all repositories
@@ -32,8 +33,8 @@ The search form provides multiple filter options:
 
 **Structured Filters** (checkboxes):
 
-* **Repository Type**: Archival / Short-term  
-* **Subject Type**: Biological specimen / Other  
+* **Repository**: Archival / Personal — decided by *where the repository lives*: **Archival** means it is in the MorphoDepot organization, **Personal** means any other account. It does not depend on anything a repository claims about itself, so an early personal repository that described itself as archival is still listed as Personal.
+* **Subject Type**: Biological specimen / Other
 * **Specimen Source**: Accessioned / Non-accessioned  
 * **In iDigBio**: Yes / No  
 * **Sex**: Male / Female / Unknown  
@@ -45,8 +46,9 @@ The search form provides multiple filter options:
 
 **Default Behavior:**
 
-* All checkboxes start checked (shows everything)  
-* Uncheck options to narrow results  
+* Most filters start with every option checked (shows everything)
+* Two do not: **Repository** starts on **Archival** only, and **Subject Type** starts on **Biological specimen** only. Tick **Personal** to see personal-account repositories as well — this is the setting people most often miss when a repository they know exists does not show up.
+* Uncheck options to narrow results
 * Filters combine using AND logic (all selected criteria must match)
 
 **8.3 Viewing Results**
@@ -56,11 +58,11 @@ The results table displays (in order):
 | Column | Description |
 | ----- | ----- |
 | Size (GB) | Volume file size (first column for quick assessment) |
-| Repo | Repository name |
-| Owner | GitHub username |
+| Repository | Repository name |
+| Owner | GitHub account or organization that owns it |
 | Species | Scientific name (or subject description) |
 | Modality | Imaging technique |
-| Last Active | Time since last commit (e.g., "3 days ago", "2 months ago") |
+| Active | Time since the repository was last pushed to (e.g., "3 days ago", "2 months ago") |
 | Spacing | Voxel spacing in mm |
 | Dimensions | Volume dimensions (voxels) |
 
@@ -70,20 +72,21 @@ The results table displays (in order):
 
 **Interactive Features:**
 
-* **Hover over a row**: Tooltip shows detailed information and screenshot thumbnails (up to 5)  
+* **Hover over a row**: Tooltip shows detailed information and screenshot thumbnails (up to 5). The table appears immediately and thumbnails fill in behind it as they download, so a first search on a cold cache is not held up by images.
 * **Click column headers**: Sort the table by any column (alphabetically or numerically)
 * **Save to CSV**: Click the **Save Search Results** button to export the current filtered results to a CSV file for external analysis or record-keeping
 
 > [!NOTE]
-> The "Last Active" column helps identify repositories that are actively maintained versus those that may be abandoned or completed projects.
+> The "Active" column helps identify repositories that are actively maintained versus those that may be abandoned or completed projects.
 
 **8.4 Taking Action**
 
 **Right-Click Context Menu**
 
-1. Right-click any repository in the table  
-2. Choose:  
-   * **"Open Repository Page"**: Opens the GitHub repository in your browser  
+1. Right-click any repository in the table
+2. Choose:
+   * **"Open Repository Page"**: Opens the GitHub repository in your browser
+   * **"Copy Repository URL"**: Puts the repository's GitHub URL on the clipboard — handy for pasting into the [Collections](./10-collections.md) member picker, or into an email
    * **"Preview in Slicer"**: Downloads and loads the data (see 8.5)
 
 Alternatively, you can double-click on any entry, which will automatically download the dataset.

--- a/MorphoDepot/9-releases.md
+++ b/MorphoDepot/9-releases.md
@@ -7,44 +7,55 @@ _MorphoDepot Tutorial · Part 9 of 10 — Releases & DOIs_
 ## **9. Releases & DOIs**
 
 > [!IMPORTANT]
-> If you are not a member of the MorphoDepot organization, the **Release** tab will be grayed out for you.
+> If you are not a member of the MorphoDepot organization, the **Release** tab is disabled for you.
 >
-> Releases are an **archival-only** feature. Only datasets created inside the **MorphoDepot organization** can be released, and a release is what mints a **citable DOI**. **Short-term (personal) repositories have no release cycle** — there is nothing to do here for them.
+> Releases are an **archival-only** feature. The Release tab lists exactly the repositories **in the MorphoDepot organization that you curate** — a personal repository is never listed and has no release cycle, so there is nothing to do here for one.
 
 A **release** is a permanent, versioned snapshot of an archival dataset's segmentation. Each release is minted a citable **Zenodo DOI**, so the dataset — and everyone who contributed to it — can be cited. Releases are cut by the dataset's **curator** (its creator) at project milestones, consolidating the contributions accepted since the last release into a new canonical baseline segmentation. The underlying scan (`source_volume`) never changes between releases; only the segmentation layer — and, optionally, the color table — does.
+
+> [!NOTE]
+> Every repository ships with a `v1` tag from the moment it is created — that is the accession snapshot, not a curated release. Your first curated release will therefore be **v2**.
 
 Everything below happens in the **Release** tab of the MorphoDepot module, in three phases.
 
 ### 9.1 Announce a deadline (call for final contributions)
 
-1. Open the **Release** tab and load the repository you curate.
-2. In the **Pre-release Announcement** section, set a **deadline** and post the announcement. This notifies everyone with an open or in-progress issue that a release is coming, so they can finish their work and sync.
-3. It also opens the window for contributors to confirm how they should be credited in the release.
+1. Open the **Release** tab, click **Refresh Github**, and double-click the repository you curate. Each row shows how many issues and pull requests are open, and hovering it lists them.
+2. Open the **Pre-release Announcement** section, set a **deadline**, edit the message if you like (`{deadline}` is replaced with the date), and click **Notify contributors**.
+3. MorphoDepot posts the message as a comment on **every open issue and pull request** — so anyone watching gets a notification — and creates a **pinned announcement issue** labelled `release-pending`, so anyone who merely visits the repository sees it too.
 
-### 9.2 Curate and build the new baseline
+If an announcement already exists, the section header says so and shows the deadline, and the button becomes **Replace announcement**: setting a new deadline edits the existing announcement in place rather than creating a second one. The announcement is retired automatically (unpinned, unlabelled, closed) once the release is submitted.
 
-1. The tab lists the segmentation contributions merged since the last release — each `issue-N` with its anatomical structure, the contributor, and the merge date.
-2. **Check the ones to include.** If any pull requests or issues are still open, you are warned — those cannot be part of this release, so resolve or defer them first.
-3. Click **Load selected for merging**. MorphoDepot assembles the checked segmentations into a new `baseline` segmentation and opens it in **Segment Editor** with the source volume, just as contributors see it.
-4. Clean up the baseline: rename segments to canonical terminology, fix boundaries, and resolve any duplicate-named segments (e.g. a structure segmented in two different issues).
-5. *(Optional)* Load an updated **color table** — a superset of the previous one that adds any new terms — so future contributors have an entry for every structure.
-6. Contributor credit for this cycle is gathered automatically; review and curate it before publishing.
+### 9.2 Build the new baseline
+
+Double-clicking the repository in the Release tab cloned its `main` branch and loaded **everything committed there** into the scene: the source volume, the color table, the current `baseline` segmentation, and one `issue-N` segmentation for every contribution merged since the last release. Assembling those into the next baseline is a manual, deliberate curation step — MorphoDepot does not merge them for you.
+
+1. Work in **Segment Editor**, or the **Segmentations** module, to build the new baseline: bring the accepted `issue-N` segments together, rename them to canonical terminology, fix boundaries, and resolve duplicates (the same structure segmented in two different issues).
+2. *(Optional)* Load an updated **color table** — a superset of the previous one that adds any new terms — so future contributors have an entry for every structure.
+3. Check the **Release comments** box: MorphoDepot has already pre-filled it with the issues closed since the last release. Add your own summary above that change log.
 
 > [!TIP]
-> When you merge, rather than editing the loaded baseline in place, **clone** the repository's current baseline, **copy** the accepted issue segments into the clone, and select the clone as the new baseline. This keeps the original pristine as a reference and makes the change unmistakable.
+> Rather than editing the loaded `baseline` in place, **clone** it in the Data module, **copy** the accepted issue segments into the clone, and select the clone as the new baseline. This keeps the original pristine as a reference and makes the change unmistakable.
 
 ### 9.3 Make the release (review → tag → DOI)
 
-1. Select the **new baseline segmentation** and the **color table** (both required), optionally **take screenshots**, and click **Make Release**.
-2. A **no-change guard** checks that the baseline actually differs from the last release, so an accidental empty release is caught before anything is published.
-3. Because archival releases are citable, the release goes through the same **editorial review** as publication: it is submitted to the MorphoDepot reviewers, who **Approve**, **Inspect**, or **Request changes**. Until it is approved, `main` is untouched and the release does not yet exist.
-4. **On approval,** MorphoDepot tags the release (`v1`, `v2`, `v3`, …), **mints the DOI through Zenodo**, and regenerates the repository's front-page `README.md` with a DOI badge and a ready-to-paste citation.
+1. Select the **New baseline segmentation** and the **Color table** — both are required, and the baseline is deliberately *not* pre-selected, so that a release cannot accidentally re-publish the old baseline. Optionally **Take Screenshot** to add new images.
+2. Click **Make release**. MorphoDepot checks the obvious mistakes first and asks you to confirm before continuing past any of them:
+   * the new baseline is **identical** to the one already committed (so the release would contain no new work);
+   * the baseline has **no segments**;
+   * the color table you picked is **not a terminology table**, or is byte-identical to the committed one although you picked a different node;
+   * **no pre-release announcement** was made, or its deadline has not passed yet.
+3. **Contributor credit.** A grid opens listing everyone who contributed a merged `issue-N` pull request since the last release. Your own name, ORCID, and affiliation are filled in automatically as lead author; fill in names for outside contributors, tick **Author?** for anyone you want cited as a co-author, and add offline contributors by hand. Contributors without a name are credited by GitHub handle. This becomes `CONTRIBUTORS.json` and the Contributors section of the README.
+4. A final summary lists exactly what the release will change — baseline, color table, README (the previous one is kept as `README-vN.md`), new screenshots, and the per-issue segmentation files that will be dropped from the working tree but kept in history. Confirm it.
+5. **Review.** Because archival releases are citable, the release goes through the same **editorial review** as publication. The release commit is pushed to a `release-candidate-vN` branch and a review request is emailed to the MorphoDepot reviewers — **`main` is untouched and the release does not yet exist**.
+6. You are then offered to **close the remaining open issues and pull requests**, since their work is already folded into the release commit.
+7. **On approval**, MorphoDepot archives the current `main` as `pre-release-vN`, fast-forwards `main` to the candidate, creates the `vN` tag, **mints the DOI through Zenodo**, and regenerates the repository's front-page `README.md` with a DOI badge and a ready-to-paste citation. If changes are requested instead, you get an email with the details and nothing is published.
 
 ### 9.4 After a release
 
 * Each release gets its own **version DOI**; a single **concept DOI** always resolves to the latest version. Both appear on the dataset's README with the citation block.
-* Contributors with work in flight should **sync their fork** to the new baseline before submitting (`git fetch upstream && git merge upstream/main`). MorphoDepot posts reminders on the affected issues and pull requests.
-* Rejected (unchecked) contributions stay in the repository as a historical record; the release notes you write should summarize what was added and who contributed.
+* Contributors do not need to run any git commands to catch up: the next time they load an assigned issue, MorphoDepot syncs their fork and starts the new branch from the released `main`. Work that was still open when the release was cut is closed with a comment asking them to open a new issue against the updated baseline.
+* Nothing is lost. Contributions you did not fold into the new baseline remain in the repository's history, as do the previous baseline, the previous README, and the `pre-release-vN` branch.
 
 > [!NOTE]
 > Releases, DOIs, and contributor credit are part of the archival workflow. For the full requirements and policy, see the **[Community Guidelines for MorphoDepot Archival Datasets](https://github.com/MorphoDepot/docs/blob/main/MorphoDepot-archival-guidelines.md)**.

--- a/MorphoDepot/README.md
+++ b/MorphoDepot/README.md
@@ -15,11 +15,12 @@ Think of **GitHub** as the "Project Manager" (where assignments and discussions 
 
 ### **Key Concepts from the Diagram:**
 
-#### **The Project Repo (The Blue Star):**  
-   * **What it is:** This is the "Main Copy" of your dataset  
-   * **Who creates it**: The Instructor/Project Owner creates this in [Section 5 (Creating the Repository)](./5-create-repo.md#5-creating-the-repository)  
-   * **Where it lives:** On GitHub, but managed through MorphoDepot  
-   * **Analogy**: Think of this as the "reference textbook" that everyone works from but nobody except the author is allowed to modify it.  
+#### **The Project Repo (The Blue Star):**
+   * **What it is:** This is the "Main Copy" of your dataset
+   * **Who creates it**: The Instructor/Project Owner creates this in [Section 5 (Creating the Repository)](./5-create-repo.md#5-creating-the-repository)
+   * **Where it lives:** On GitHub, but managed through MorphoDepot. It is either a **Personal** repository on your own GitHub account, or an **Archival** repository in the MorphoDepot organization — that choice is made once, when you create it, and it decides where the data lives, whether the dataset gets a citable DOI, and who governs it. See [Section 5](./5-create-repo.md#repository-type-personal-vs-archival).
+   * **How it is created:** in two steps — it is first **staged** privately, so you can correct it as often as you need, and only then **published**. The scan itself is fixed once staged.
+   * **Analogy**: Think of this as the "reference textbook" that everyone works from but nobody except the author is allowed to modify it.
 
 #### **Task Management (Purple Box):**  
    * **Location:** GitHub Website.  
@@ -27,7 +28,7 @@ Think of **GitHub** as the "Project Manager" (where assignments and discussions 
 
 #### **The Fork (Blue Branch Icon):**  
    * **What it is:** An independent copy of the project created under the student’s github account.  
-   * **When it happens:** Automatically created when a student first loads an assigned issue in MorphoDepot.  
+   * **When it happens:** Automatically created when a student first loads an assigned issue in MorphoDepot, and kept in step with the main copy every time they load another one.
    * **Why it matters:** Students don't edit the main repo directly—they work on their own safe copy  
    * **Analogy:** Like making edits on a photocopy of a library book, not in the book itself  
 
@@ -80,14 +81,14 @@ Think of **GitHub** as the "Project Manager" (where assignments and discussions 
 ### **Summary: The Complete MorphoDepot Cycle**
 
 1. **Instructor** creates the project repository with volume and color table (and optionally with an existing segmentation).  
-2. **Student** creates an Issue requesting to work on a specific structure  
-3. **Instructor** assigns the Issue to the student  
+2. **Student** creates an Issue requesting to work on a specific structure
+3. The Issue is assigned to that student — automatically, if the repository was created with auto-assignment on; otherwise the **Instructor** assigns it
 4. **Student** loads the issue in MorphoDepot, which automatically creates a Fork  
 5. **Student** segments and commits frequently to save progress  
 6. **Student** requests review when finished  
 7. **Instructor** reviews and either approves (merge) or requests changes  
 8. If changes needed, student revises and resubmits  
-9. Once approved, work is merged into the Master Copy  
+9. Once approved, work is merged into the Master Copy
 10. **Instructor** creates [versioned releases](./9-releases.md) at project milestones (archival datasets only)
 
 **The beauty of this system**: Everyone works independently on their own copy, preventing conflicts, while the repository owner maintains quality control before any work becomes "official."
@@ -99,10 +100,10 @@ Think of **GitHub** as the "Project Manager" (where assignments and discussions 
 This tutorial is split into 10 parts. Work through them in order, or jump straight to the part you need:
 
 1. **[Prerequisites & System Configuration](./1-prerequisites.md)** — GitHub account, 2FA, and installing git + gh.
-2. **[Slicer Installation & Setup](./2-slicer-setup.md)** — Install Slicer and the extensions, then verify the connection.
-3. **[Preparing Data: 3D Volume](./3-prepare-volume.md)** — Clean, reorient, crop, and name your source volume.
+2. **[Slicer Installation & Setup](./2-slicer-setup.md)** — Install Slicer and the extensions, verify the connection, and keep MorphoDepot up to date.
+3. **[Preparing Data: 3D Volume](./3-prepare-volume.md)** — Clean, reorient, crop, and name your source volume — and what becomes unchangeable once you stage it.
 4. **[Preparing Data: Color Table](./4-color-table.md)** — Define the anatomical labels and terminologies.
-5. **[Creating the Repository](./5-create-repo.md)** — Fill the accession form, add screenshots, and create the repo.
+5. **[Creating the Repository](./5-create-repo.md)** — Choose Personal or Archival, stage the repository privately, then publish it.
 6. **[Project Management & Assignments](./6-project-management.md)** — Issues, assignments, segmenting, and committing work.
 7. **[Reviewing & Merging Submissions](./7-review.md)** — Review pull requests and approve or request changes.
 8. **[Search & Discovery](./8-search.md)** — Find and preview existing MorphoDepot repositories.


### PR DESCRIPTION
The MorphoDepot tutorial was last touched on **2026-07-02**; the extension has moved a long way since. This reconciles all ten pages against a full read of `MorphoDepot.py` and `MorphoDepotLib/*`.

## The two things this was asked for

**1. "Short-term" is gone.** The dichotomy is strictly **Personal vs. Archival (organization)** — the extension's own label since #195, and the owner-based classification Search has used since #194. A short-lived classroom repository is now given as *one common reason* to pick Personal, alongside wanting full control, not being a member yet, trying the workflow out, or data you cannot commit to permanently — not as the definition of the type.

**2. Staging is explained.** Part 3 now leads with what "Create" actually does, and Part 3 + Part 5 both state plainly what a stage freezes versus what stays editable:

| Frozen at staging | Editable while staged |
| --- | --- |
| the source volume | the whole accession form |
| its voxel dimensions and spacing | the license |
| the repository name | the color table (replace the node) |
| the repository type | the baseline segmentation (replace the node) |
| the owner (your account / the org) | the screenshots |

The spacing/dimensions row is the one nobody could have guessed: they are read once at staging and carried over verbatim on every later save, so a wrong voxel size cannot be fixed by editing — only by discarding and re-staging.

Part 5 also gains a **Managing staged repositories** section: reopen by double-click, Save Changes as often as you like, right-click → Publish for an approved archival dataset, Discard, and the week/four-week reminder policy from #209.

## Other reconciliations

- **Part 2** — the in-place update mechanism: the banner, Update Now / What's New / Dismiss, Reload vs. Restart, the Configure tab's *MorphoDepot Version* section, and which installations MorphoDepot will and will not write to (#203/#206/#207/#208). Also per-repository `gh` sign-in (#215) and git/gh living off the system PATH (#214).
- **Part 3** — 2 GB is the *personal* limit (GitHub attachment); organization repositories go to Jetstream2 with a 10 GB cap. Plus the scalar-volume requirement and the real node-name rule.
- **Part 4** — color-table naming rule, and terminology being mandatory for archival (generic/built-in tables are rejected outright) but auto-fillable for personal.
- **Part 6** — auto-assignment of new issues to their creators, and work lists read live from GitHub (#216) instead of an index that could lag.
- **Part 7** — the button is **Open PR page** in the Annotate tab, not "PR Link"; reviewer scope is repos you own plus org repos whose `CURATOR` names you; note on the reviewers-only section (#201).
- **Part 8** — the filter is **Repository (Archival / Personal)**, decided by owner and defaulting to **Archival only** (the reason a repository "is missing" from search); corrected column names; lazy thumbnails (#218); Copy Repository URL; collections excluded (#197).
- **Part 9** — `v1` is the accession snapshot, so the first curated release is **v2**; the new baseline is assembled by hand from the issue segmentations loaded into the scene (the old text described a "Load selected for merging" control and a contribution checklist that do not exist); the real guards, the contributor-credit grid, the release-candidate branch review, and the post-release cleanup.
- **Part 10** — collections get an opaque `collection-<hash>` name and carry their title in the repository *description*; near-duplicate title warning; pasted members are validated.

## Noted, not changed here

- `accession_form.py` links to `https://github.com/MorphoDepot/MorphoDepot/wiki/Repository-naming` for naming guidance — that URL is a **404**.
- Five **user-visible** extension strings still say "Short-term" even when the user picked **Personal**: the Archival radio's non-member tooltip (`widget_create.py:453`), the "Membership required" dialog (`:470`), the "Couldn't verify membership" dialog (`:765`), the org-destination confirmation header (`:1283`), and — most visibly — the staging confirmation dialog's `Repository Type:` line (`:1348`), which prints the raw accession value. The accession form's `repoType` question itself is *deliberately* retained unchanged for schema stability and should **not** be renamed; the fix is to map that stored value to a display label at `:1348` and to reword the four prose strings.
- `MorphoDepot/docs/MorphoDepot-archival-guidelines.md` still uses "Short-term" in its "Two kinds of dataset" table.
- Search still labels one filter **In iDigBio: Yes / No** (`search_form.py` `shortLabels`) although the accession question behind it was broadened to GBIF / iDigBio / Arctos. The tutorial documents the label users actually see; the rename belongs in the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

